### PR TITLE
publish method sends multiple events

### DIFF
--- a/bus/bus.js
+++ b/bus/bus.js
@@ -142,13 +142,7 @@ Bus.prototype._publish = function _publish(queueName, message, cid) {
       self.initialized = true;
       self._publish(queueName, message);
     };
-    var timeout = function() {
-      self.connection.removeListener('ready', republish);
-      process.nextTick(republish);
-    };
-    var timeoutId = setTimeout(timeout, 1000);
     self.connection.on('ready', function() {
-      clearTimeout(timeoutId);
       process.nextTick(republish);
     });
   }


### PR DESCRIPTION
The publish method can send multiple events if the connection is not initialized.
