### PR TITLE
'readyToPublish' event is firing each time a PubSubQ is created

### DIFF
--- a/bus/pubsubqueue.js
+++ b/bus/pubsubqueue.js
@@ -88,7 +88,7 @@ function PubSubQueue (connection, queueName, options) {
 PubSubQueue.prototype.publish = function publish (event) {
   var self = this;
   if ( ! this.exchange) {
-    this.connection.on('readyToPublish', function () {
+    this.connection.once('readyToPublish', function () {
       self.publish(event);
     });
   } else {


### PR DESCRIPTION
The 'readyToPublish' event is fired for each PubSubQueue instantiation,
and since the connection object is shared it re-fires this for all existing
PubSubs
