### PR TITLE
fix republish function call: fixes #12

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -134,7 +134,7 @@ RabbitMQBus.prototype.publish = function publish (queueName, message) {
   } else {
     var republish = function() {
       self.initialized = true;
-      self._publish(queueName, message);
+      self.publish(queueName, message);
     };
     self.connection.on('ready', function() {
       process.nextTick(republish);


### PR DESCRIPTION
This was causing an issue if publishing a message before the amqp connection had been established
