### PR TITLE
custom exchange name and options on bus.publish

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -16,6 +16,8 @@ function RabbitMQBus(options, implOpts) {
   options = options || {}, implOpts, self = this;
   options.url = options.url || process.env.RABBITMQ_URL || 'amqp://localhost';
   options.vhost = options.vhost || process.env.RABBITMQ_VHOST || '/';
+  options.exchangeName = options.exchangeName || 'amq.topic';
+  options.exchangeOptions = options.exchangeOptions || {};
 
   this.correlator = new Correlator(options);  
   this.delayOnStartup = options.delayOnStartup || 10;

--- a/bus/rabbitmq/pubsubqueue.js
+++ b/bus/rabbitmq/pubsubqueue.js
@@ -11,9 +11,15 @@ function PubSubQueue (options) {
   this.log = options.log;
   this.maxRetries = options.maxRetries || 3;
   this.queueName = options.queueName;
-  this.rejected = {}; 
+  this.rejected = {};
+  this.exchangeName = this.connection.options.exchangeName;
+  this.exchangeOptions = {
+    type: this.connection.options.exchangeOptions.type || 'topic',
+    durable: this.connection.options.exchangeOptions.durable === false ? false : true,
+    autoDelete: this.connection.options.exchangeOptions.autoDelete || false
+  };
   var self = this;
-  this.connection.exchange('amq.topic', { type: 'topic', durable: true, autoDelete: false }, function (exchange) {
+  this.connection.exchange(this.exchangeName, this.exchangeOptions, function (exchange) {
     self.exchange = exchange;
     self.connection.emit('readyToPublish');
   });


### PR DESCRIPTION
allows to specify custom exchange name and options for pub/sub events
var bus = require('servicebus').bus({exchangeName: ‘custom-exchange’,
exchangeOptions: {durable:false, autoDelete:true, topic:’fanout’}});
