### PR TITLE
add contentType, deliveryMode and replyTo as customisable options when p...

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -182,7 +182,7 @@ RabbitMQBus.prototype.publish = function publish (queueName, message, options) {
     }
     self.handleOutgoing(options.queueName, message, function (queueName, message) {
       log('sending to queue ' + queueName + ' event ' + util.inspect(message));
-      self.pubsubqueues[queueName].publish(message);
+      self.pubsubqueues[queueName].publish(message, options);
     });
 
   });

--- a/bus/rabbitmq/pubsubqueue.js
+++ b/bus/rabbitmq/pubsubqueue.js
@@ -25,17 +25,25 @@ function PubSubQueue (options) {
   });
 };
 
-PubSubQueue.prototype.publish = function publish (event) {
+PubSubQueue.prototype.publish = function publish (event, options) {
   var self = this;
   if ( ! this.exchange) {
     this.connection.setMaxListeners(Infinity);
     this.connection.once('readyToPublish', function () {
-      self.publish(event);
+      options = {
+        contentType: options.contentType || 'application/json',
+        deliveryMode: options.deliveryMode || 2,
+        replyTo: options.replyTo || null
+      };
+      self.publish(event, options);
     });
   } else {
     this.log('publishing to exchange ' + self.exchange.name + ' ' + self.queueName + ' event ' + util.inspect(event));
     setImmediate(function () {
-      self.exchange.publish(self.queueName, event, { contentType: 'application/json', deliveryMode: 2 });
+      if ( ! options.replyTo) {
+        delete options.replyTo;
+      }
+      self.exchange.publish(self.queueName, event, options);
     });
   }
 };


### PR DESCRIPTION
...ublishing a message

can overwrite default options by passing them when publishing a message:
bus.publish(‘my.event’, {
    “hello”: “world”
  }, {replyTo: ‘my client’, contentType: ‘application/octet-stream’,
deliveryMode: 1})
