### PR TITLE
0.4.7 ready - tests are ok - exhange options and publish options

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -182,7 +182,14 @@ RabbitMQBus.prototype.publish = function publish (queueName, message, options) {
     }
     self.handleOutgoing(options.queueName, message, function (queueName, message) {
       log('sending to queue ' + queueName + ' event ' + util.inspect(message));
-      self.pubsubqueues[queueName].publish(message);
+      var publishOptions = {
+        contentType: options.contentType || 'application/json',
+        deliveryMode: options.deliveryMode ||  2
+      };
+      if (options.replyTo) {
+        publishOptions.replyTo = options.replyTo;
+      };
+      self.pubsubqueues[queueName].publish(message, publishOptions);
     });
 
   });

--- a/bus/rabbitmq/pubsubqueue.js
+++ b/bus/rabbitmq/pubsubqueue.js
@@ -26,17 +26,17 @@ function PubSubQueue (options) {
   });
 };
 
-PubSubQueue.prototype.publish = function publish (event) {
+PubSubQueue.prototype.publish = function publish (event, publishOptions) {
   var self = this;
   if ( ! this.exchange) {
     this.connection.setMaxListeners(Infinity);
     this.connection.once('readyToPublish', function () {
-      self.publish(event);
+      self.publish(event, publishOptions);
     });
   } else {
     this.log('publishing to exchange ' + self.exchange.name + ' ' + self.queueName + ' event ' + util.inspect(event));
     setImmediate(function () {
-      self.exchange.publish(self.queueName, event, { contentType: 'application/json', deliveryMode: 2 });
+      self.exchange.publish(self.queueName, event, publishOptions);
     });
   }
 };

--- a/bus/rabbitmq/pubsubqueue.js
+++ b/bus/rabbitmq/pubsubqueue.js
@@ -12,11 +12,12 @@ function PubSubQueue (options) {
   this.maxRetries = options.maxRetries || 3;
   this.queueName = options.queueName;
   this.rejected = {};
-  this.exchangeName = this.connection.options.exchangeName;
+  this.exchangeName = this.connection.options.exchangeName || 'amq.topic';
+  var exchangeOptions = this.connection.options.exchangeOptions || {};
   this.exchangeOptions = {
-    type: this.connection.options.exchangeOptions.type || 'topic',
-    durable: this.connection.options.exchangeOptions.durable === false ? false : true,
-    autoDelete: this.connection.options.exchangeOptions.autoDelete || false
+    type: exchangeOptions.type || 'topic',
+    durable: exchangeOptions.durable === false ? false : true,
+    autoDelete: exchangeOptions.autoDelete || false
   };
   var self = this;
   this.connection.exchange(this.exchangeName, this.exchangeOptions, function (exchange) {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
-  "author": "Thibault Laurens <laurens.thibault@gmail.com>",
+  "author": "Matt Walters <mattwalters5@gmail.com>",
   "contributors": [
-      "mattwalters5@gmail.com",
-      "timisbusy@gmail.com",
-      "mail@chrisabrams.com",
-      "laurens.thibault@gmail.com"
+    "mattwalters5@gmail.com",
+    "timisbusy@gmail.com",
+    "mail@chrisabrams.com"
   ],
-  "name": "hera-servicebus",
+  "name": "servicebus",
   "description": "Simple service bus for sending events between processes using amqp.",
   "version": "0.4.7",
-  "homepage": "https://github.com/ThibaultLaurens/servicebus",
+  "homepage": "https://github.com/mateodelnorte/servicebus",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ThibaultLaurens/servicebus.git"
+    "url": "git://github.com/mateodelnorte/servicebus.git"
   },
   "engines": {
     "node": "0.6 || 0.8 || 0.9 || 0.10"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-  "author": "Matt Walters <mattwalters5@gmail.com>",
+  "author": "Thibault Laurens <laurens.thibault@gmail.com>",
   "contributors": [
-    "mattwalters5@gmail.com",
-    "timisbusy@gmail.com",
-    "mail@chrisabrams.com"
+      "mattwalters5@gmail.com",
+      "timisbusy@gmail.com",
+      "mail@chrisabrams.com",
+      "laurens.thibault@gmail.com"
   ],
-  "name": "servicebus",
+  "name": "hera-servicebus",
   "description": "Simple service bus for sending events between processes using amqp.",
   "version": "0.4.7",
-  "homepage": "https://github.com/mateodelnorte/servicebus",
+  "homepage": "https://github.com/ThibaultLaurens/servicebus",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mateodelnorte/servicebus.git"
+    "url": "git://github.com/ThibaultLaurens/servicebus.git"
   },
   "engines": {
     "node": "0.6 || 0.8 || 0.9 || 0.10"


### PR DESCRIPTION
It should bring a bit more flexibility when doing pub/sub with the service bus. To summarise, you can now declare your bus with custom exchange name and options like this:
bus = require('servicebus').bus({url: "myurl", exchangeName: "myexchange", exchangeOptions: {durable:false, type: "fanout", autoDelete: true}})

Another thing is when publishing a message you may want to specify contentType, deliveryMode or replyTo preperties as well. You can then do
bus.publish('my.event', {hello:'world'}, {replyTo: "my.client", contentType: "application/octet-stream", deliveryMode: 1})

The tests are passing this time, I guess we can bring it to 0.4.7.
Thank you.