### PR TITLE
Added property middleware for persisting message properties into message...

### DIFF
--- a/bus/bus.js
+++ b/bus/bus.js
@@ -77,5 +77,6 @@ Bus.prototype.correlate = require('./middleware/correlate');
 Bus.prototype.logger = require('./middleware/logger');
 Bus.prototype.package = require('./middleware/package');
 Bus.prototype.retry = require('./middleware/retry');
+Bus.prototype.property = require('./middleware/property');
 
 module.exports = Bus;

--- a/bus/middleware/property.js
+++ b/bus/middleware/property.js
@@ -1,0 +1,19 @@
+var warn = require('debug')('servicebus:warn');
+
+function addMessageProperties (channel, message, options, next) {
+  if (typeof message.content === 'object') {
+    if (!message.content.properties) {
+      message.content.properties = message.properties;
+    }
+  } else {
+    warn('Property middleware requires the use of middleware .package.');
+  }
+
+  next(null, channel, message, options, next);
+}
+
+module.exports = function () {
+  return {
+    handleIncoming: addMessageProperties
+  };
+};

--- a/test/bus-shim.js
+++ b/test/bus-shim.js
@@ -11,5 +11,6 @@ bus.use(bus.package());
 bus.use(bus.correlate());
 bus.use(bus.logger());
 bus.use(bus.retry());
+bus.use(bus.property());
 
 module.exports.bus = bus;

--- a/test/middleware/property.js
+++ b/test/middleware/property.js
@@ -1,0 +1,22 @@
+var noop = function () {};
+var log = require('debug')('servicebus:test')
+var bus = require('../bus-shim').bus;
+
+// the following code is being used in the above shim
+// var pack = require('../../bus/middleware/package');
+
+// bus.use(pack());
+
+describe('property', function() {
+
+  it('should add a properties property in message if an options is passed as third argument in producers', function (done) {
+    bus.listen('my.message.props', function (message) {
+      message.should.have.property('properties');
+      done();
+    });
+    setTimeout(function () {
+      bus.send('my.message.props', { my: 'message' }, { test: 'property' });
+    }, 1000);
+  });
+
+});


### PR DESCRIPTION
... content.

 Copying from rabbitmq.com:

> Message properties
> 
> The AMQP protocol predefines a set of 14 properties that go with a message. Most of the properties are rarely used, with the exception of the following:
> 
> delivery_mode: Marks a message as persistent (with a value of 2) or transient (any other value). You may remember this property from the second tutorial.
> content_type: Used to describe the mime-type of the encoding. For example for the often used JSON encoding it is a good practice to set this property to: application/json.
> reply_to: Commonly used to name a callback queue.
> correlation_id: Useful to correlate RPC responses with requests.

The `.property` middleware if used will add a `.properties` property in messages.
