### PR TITLE
Local rejected count in incoming headers

### DIFF
--- a/bus/middleware/retry.js
+++ b/bus/middleware/retry.js
@@ -29,6 +29,7 @@ function retryLocal (channel, message, options, next) {
   var onlyRejectMax = createOnly('reject', maxRetries);
 
   if (options && options.ack) {
+    message.properties.headers.rejected = localRejected[message.content.cid];
 
     message.content.handle = {
       ack: function () { 

--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -127,7 +127,9 @@ RabbitMQBus.prototype.destroyListener = function removeListener (queueName) {
   if (this.queues[queueName] === undefined) {
     throw new Error('no queue currently listening at ' + queueName);
   } else {
-    return this.queues[queueName].destroy();
+    var q = this.queues[queueName];
+    delete this.queues[queueName];
+    return q.destroy();
   }
 };
 


### PR DESCRIPTION
Modify headers of incoming messages when using local retry so user can use logic depending on, for example, whether the message is expected to be redelivered.