### PR TITLE
allowing vhost to be specified in url

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -16,7 +16,7 @@ function RabbitMQBus (options) {
 
   options = options || {};
   options.url = options.url || process.env.RABBITMQ_URL || 'amqp://localhost';
-  options.vhost = options.vhost || process.env.RABBITMQ_VHOST || '/';
+  options.vhost = options.vhost || process.env.RABBITMQ_VHOST;
   options.exchangeName = options.exchangeName || 'amq.topic';
   options.exchangeOptions = options.exchangeOptions || {};
 
@@ -32,8 +32,8 @@ function RabbitMQBus (options) {
   this.queues = {};
   this.queuesFile = options.queuesFile;
 
-  var vhost = util.format('/%s', querystring.escape(options.vhost));
-  var url = util.format('%s%s', options.url, vhost);
+  var vhost = options.vhost && util.format('/%s', querystring.escape(options.vhost));
+  var url = vhost ? util.format('%s%s', options.url, vhost) : options.url;
 
   self.log('connecting to rabbitmq on %s', url);
 
@@ -186,7 +186,7 @@ RabbitMQBus.prototype.send = function send (queueName, message, options, cb) {
     cb = options;
     options = {};
   }
-  
+
   options = options || {};
 
   if (cb && ! this.confirmChannel) return cb(new Error('callbacks only supported when created with bus({ enableConfirms:true })'))


### PR DESCRIPTION
Ran into the same problem as discussed in issue #53. This change would allow the vhost to be specified within `options.url` while still allowing the use of `options.vhost` (which is prepended to the url).