### PR TITLE
Retry middleware crashes when `headers' prop does not exists

### DIFF
--- a/bus/middleware/retry.js
+++ b/bus/middleware/retry.js
@@ -68,7 +68,11 @@ function retryLocal (channel, message, options, next) {
   next(null, channel, message, options);
 }
 
-function retryDistributed (channel, message, options, next) {    
+function retryDistributed (channel, message, options, next) {
+
+  if (message.properties.headers === undefined) {
+    message.properties.headers = {};
+  }
 
   if (message.properties.headers.rejected === undefined) {
     message.properties.headers.rejected = 0;


### PR DESCRIPTION
Playing with another client like ruby and bunny I realized that the `headers` property is not necessarily present and makes `retryDistributed` crash

consider receiver.js
```javascript
var bus = require('servicebus').bus();
var _ = require('lodash');

bus.use(bus.retry());

bus.listen('my.queue', { ack: true }, function (job) {
  console.log(_.omit(job, 'handle'));
  job.handle.ack();
});
```
and sender.rb
```ruby
# encoding: utf-8

require 'bunny'
require 'json'

conn = Bunny.new
conn.start

ch = conn.create_channel
q = ch.queue("my.queue", :durable => true, :auto_delete => false)

opts = {}

i = 0
while true
  payload = { "my" => "queue", "i" => i }
  q.publish(payload.to_json, opts)
  puts payload
  i += 1
  sleep 0.1
end
```

retry middleware crash on
```javascript
events.js:142
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property 'rejected' of undefined
    at RabbitMQBus.retryDistributed (bus/middleware/retry.js:73:33)
    at RabbitMQBus.next (bus/bus.js:42:20)
    at RabbitMQBus.Bus.handleIncoming (bus/bus.js:48:15)
    at listenChannel.consume.noAck (bus/rabbitmq/queue.js:95:14)
    at Channel.BaseChannel.dispatchMessage (node_modules/amqplib/lib/channel.js:466:12)
    at Channel.BaseChannel.handleDelivery (node_modules/amqplib/lib/channel.js:475:15)
    at emitOne (events.js:78:13)
    at Channel.emit (events.js:170:7)
```

which does not happen with initialized headers property on my sender.rb example
```ruby
opts = {:headers => []}
```

It would be nice to support message from foreign clients with no `headers` property in it