### PR TITLE
package middleware honors existing cid; removes cid from message data

### DIFF
--- a/bus/middleware/package.js
+++ b/bus/middleware/package.js
@@ -10,6 +10,11 @@ function packageMessage (queueName, message, options, next) {
     , type: message.type || queueName
   };
 
+  if (message.hasOwnProperty('cid')) {
+    newMessage.cid = message.cid;
+    delete newMessage.data.cid;
+  }
+
   next(null, queueName, newMessage, options);
 
 }

--- a/bus/middleware/package.js
+++ b/bus/middleware/package.js
@@ -10,7 +10,7 @@ function packageMessage (queueName, message, options, next) {
     , type: message.type || queueName
   };
 
-  if (message.hasOwnProperty('cid')) {
+  if (message.cid) {
     newMessage.cid = message.cid;
     delete newMessage.data.cid;
   }

--- a/test/middleware/package.js
+++ b/test/middleware/package.js
@@ -1,6 +1,7 @@
 var noop = function () {};
-var log = require('debug')('servicebus:test')
+var log = require('debug')('servicebus:test');
 var bus = require('../bus-shim').bus;
+var uuid = require('node-uuid');
 
 // the following code is being used in the above shim
 // var pack = require('../../bus/middleware/package');
@@ -10,14 +11,27 @@ var bus = require('../bus-shim').bus;
 describe('package', function() {
 
   it('should repackage message into data property and provide a datetime and type property equal to the queue name', function (done) {
-    bus.listen('my.message.type', function (message) {
+    bus.listen('my.message.package', function (message) {
       message.should.have.property('data');
       message.should.have.property('datetime');
-      message.should.have.property('type', 'my.message.type');
+      message.should.have.property('type', 'my.message.package');
       done();
     });
     setTimeout(function () {
-      bus.send('my.message.type', { my: 'message' });
+      bus.send('my.message.package', { my: 'message' });
+    }, 1000);
+  });
+
+  it('should honor message correlation id when packaging', function (done) {
+    bus.listen('my.message.package.1', function (message) {
+      message.should.have.property('cid');
+      message.should.have.property('data');
+      message.should.have.property('datetime');
+      message.should.have.property('type', 'my.message.package.1');
+      done();
+    });
+    setTimeout(function () {
+      bus.send('my.message.package.1', { cid: uuid(), my: 'message' });
     }, 1000);
   });
 


### PR DESCRIPTION
This patch has the package middleware honor an existing cid.

However; this changes the behavior referenced: https://github.com/mateodelnorte/servicebus/issues/28#issuecomment-67271130

Correlation id will be kept as a part of the core message and will not appear in the message data.
