### PR TITLE
Bug: unsubscripe fails for multiple subscriptions on persistent queue

### DIFF
--- a/bus/rabbitmq/pubsubqueue.js
+++ b/bus/rabbitmq/pubsubqueue.js
@@ -69,12 +69,14 @@ PubSubQueue.prototype.publish = function publish (event, options, cb) {
 
 PubSubQueue.prototype.subscribe = function subscribe (options, callback) {
   var self = this;
+  var listening = false;
+  var subscription = null;
 
   function _unsubscribe (cb) {
-    if (self.listening) {
-      // cancel misses callback version so we have to use the promise
+    if (listening) {
+      // should we prevent multiple cancel calls?
       self.listenChannel
-        .cancel(self.subscription.consumerTag)
+        .cancel(subscription.consumerTag)
         .then(function () {
           self.emit('unlistened');
           if (cb) {
@@ -117,8 +119,8 @@ PubSubQueue.prototype.subscribe = function subscribe (options, callback) {
       });
     }, { noAck: ! self.ack })
       .then(function (ok) {
-        self.listening = true;
-        self.subscription = { consumerTag: ok.consumerTag };
+        listening = true;
+        subscription = { consumerTag: ok.consumerTag };
         self.emit('listening');
       });
   }

--- a/test/subscribe-unsubscribe.js
+++ b/test/subscribe-unsubscribe.js
@@ -16,18 +16,123 @@ describe('servicebus', function () {
   });
 
   describe('#subscribe & #unsubscribe', function () {
-    it('should complete subscribe/unsubscribe cycle', function (done) {
-      const subscription = bus.subscribe('my.event.11', function (event) {});
+    describe('on temporary queues', function () {
+      it('should complete subscribe/unsubscribe cycle', function (done) {
+        const subscription = bus.subscribe('test.subunsub.1', function (event) {});
 
-      subscription
-        .should.not.equal(bus)
-        .and.be.a.Object()
-        .and.have.ownProperty('unsubscribe');
-      subscription.unsubscribe
-        .should.be.a.Function();
+        subscription
+          .should.not.equal(bus)
+          .and.be.a.Object()
+          .and.have.ownProperty('unsubscribe');
+        subscription.unsubscribe
+          .should.be.a.Function();
 
-      subscription.unsubscribe(function () {
-        done();
+        subscription.unsubscribe(function () {
+          done();
+        });
+      });
+
+      it('should not receive events after unsubscribe', function (done) {
+        const subscription = bus.subscribe('test.subunsub.2', function (event) {
+          throw new Error('unexpected event');
+        });
+        subscription.unsubscribe(function () {
+          bus.publish('test.subunsub.2', {test: 2});
+          setTimeout(function () {
+            done();
+          }, 100);
+        });
+      });
+
+      it('should not receive events after multiple subscribes/unsubscribes', function (done) {
+        var receivedEvents = 0;
+        const subscription1 = bus.subscribe('test.subunsub.3', function (event) {
+          receivedEvents += 1;
+        });
+        const subscription2 = bus.subscribe('test.subunsub.3', function (event) {
+          receivedEvents += 1;
+        });
+
+        var subscriptions = 2;
+        const onUnsubscribed = function () {
+          subscriptions -= 1;
+          if (subscriptions == 0) {
+            bus.publish('test.subunsub.3', {test: 2});
+            setTimeout(function () {
+              receivedEvents.should.be.equal(0);
+              done();
+            }, 100);
+          }
+        };
+
+        subscription1.unsubscribe(onUnsubscribed());
+        subscription2.unsubscribe(onUnsubscribed());
+      });
+    });
+
+    describe('on persistent queues', function () {
+      const testQueue = 'test.subunsub.persistent';
+      function _subscribe(eventHandler) {
+        return bus.subscribe(testQueue, {ack: true}, eventHandler);
+      }
+
+      afterEach(function (done) {
+        // drain queue
+        var drainedEvents = 0;
+        const subscription = _subscribe(function (event) {
+          drainedEvents += 1;
+          event.handle.ack();
+        });
+        setTimeout(function () {
+          subscription.unsubscribe();
+          done();
+        }, 200);
+      });
+
+      it('should not receive events after unsubscribe', function (done) {
+        const ts = Date.now();
+        var receivedEvents = 0;
+        const subscription = _subscribe(function (event) {
+          console.log(ts, event);
+          receivedEvents += 1;
+          event.handle.ack();
+        });
+        setTimeout(function () {
+          subscription.unsubscribe(function () {
+            bus.publish(testQueue, {test: 3, ts: ts}, {ack: true});
+            setTimeout(function () {
+              receivedEvents.should.be.equal(0);
+              done();
+            }, 100);
+          });
+        }, 100);
+      });
+
+      it('should not receive events after multiple subscribes/unsubscribes', function (done) {
+        var receivedEvents = 0;
+        const subscription1 = _subscribe(function (event) {
+          receivedEvents += 1;
+          event.handle.ack();
+        });
+        const subscription2 = _subscribe(function (event) {
+          receivedEvents += 1;
+          event.handle.ack();
+        });
+
+        var subscriptions = 2;
+        const onUnsubscribed = function () {
+          subscriptions -= 1;
+          if (subscriptions == 0) {
+            bus.publish(testQueue, {test: 4});
+            setTimeout(function () {
+              receivedEvents.should.be.equal(0);
+              done();
+            }, 250);
+          }
+        };
+
+        subscription1.unsubscribe(onUnsubscribed());
+        subscription2.unsubscribe(onUnsubscribed());
       });
     });
   });

--- a/test/subscribe-unsubscribe.js
+++ b/test/subscribe-unsubscribe.js
@@ -123,7 +123,7 @@ describe('servicebus', function () {
         const onUnsubscribed = function () {
           subscriptions -= 1;
           if (subscriptions == 0) {
-            bus.publish(testQueue, {test: 4});
+            bus.publish(testQueue, {test: 4}, {ack: true});
             setTimeout(function () {
               receivedEvents.should.be.equal(0);
               done();
@@ -131,8 +131,10 @@ describe('servicebus', function () {
           }
         };
 
-        subscription1.unsubscribe(onUnsubscribed());
-        subscription2.unsubscribe(onUnsubscribed());
+        setTimeout(function () {
+          subscription1.unsubscribe(onUnsubscribed);
+          subscription2.unsubscribe(onUnsubscribed);
+        }, 100);
       });
     });
   });


### PR DESCRIPTION
This PR does not fix the issue but introduces tests to prove the issue.

The issue: multiple subscriptions on a persistent queue get created and destroyed via unsubscribe calls afterwards. It is expected that after successful unsubscribing no more events are received. Right now the callback provided to subscribe still gets called after unsubscribtion.