### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Servicebus allows for middleware packages to enact behavior at the time a messag
   bus.use(bus.package());
   bus.use(bus.correlate());
   bus.use(bus.logger());
-  bus.use(bus.retry());
 
   module.exports.bus = bus;
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Servicebus allows for middleware packages to enact behavior at the time a messag
   module.exports.bus = bus;
 ```
 
- Middleware may defined one or two functions to modify incoming or outgoing messages:
+ Middleware may define one or two functions to modify incoming or outgoing messages:
 
 ```
 ...

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Servicebus allows for middleware packages to enact behavior at the time a messag
 
   bus.use(bus.package());
   bus.use(bus.correlate());
-  bus.use(bus.log());
+  bus.use(bus.logger());
   bus.use(bus.retry());
 
   module.exports.bus = bus;


### PR DESCRIPTION
minor spelling
syntax error `bus.log()` should be `bus.logger()`
remove old `bus.retry()` middleware example