### PR TITLE
Pass through channel/connection close events

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -40,8 +40,8 @@ function RabbitMQBus (options, implOpts) {
 
   amqp.connect(url, implOpts).then(function (conn) {
 
-    conn.on('close', channelMiscEvent('connection_close'));
-    conn.on('error', channelMiscEvent('connection_error'));
+    conn.on('close', channelEvent('connection_close'));
+    conn.on('error', channelEvent('connection_error'));
 
     self.connection = conn;
 
@@ -50,9 +50,9 @@ function RabbitMQBus (options, implOpts) {
       self.emit('error', err);
     }
 
-    function channelMiscEvent(name) {
-      return (payload) => { 
-        self.log('channel event %s: %s', name, payload);
+    function channelEvent(name) {
+      return function (payload) {
+        self.log('channel event: %s (%s)', name, payload);
         self.emit(name, payload);
       };
     }
@@ -67,7 +67,7 @@ function RabbitMQBus (options, implOpts) {
 
     self.connection.createChannel().then(function (channel) {
       channel.on('error', channelError);
-      channel.on('close', channelMiscEvent('channel_close'));
+      channel.on('close', channelEvent('channel_close'));
       self.sendChannel = channel;
       if (options.prefetch) {
         self.sendChannel.prefetch(options.prefetch);
@@ -78,7 +78,7 @@ function RabbitMQBus (options, implOpts) {
 
     self.connection.createChannel().then(function (channel) {
       channel.on('error', channelError);
-      channel.on('close', channelMiscEvent('channel_close'));
+      channel.on('close', channelEvent('channel_close'));
       self.listenChannel = channel;
       if (options.prefetch) {
         self.listenChannel.prefetch(options.prefetch);
@@ -90,7 +90,7 @@ function RabbitMQBus (options, implOpts) {
     if (options.enableConfirms) {
       self.connection.createConfirmChannel().then(function (channel) {
         channel.on('error', channelError);
-        channel.on('close', channelMiscEvent('channel_close'));
+        channel.on('close', channelEvent('channel_close'));
         self.confirmChannel = channel;
         if (options.prefetch) {
           self.confirmChannel.prefetch(options.prefetch);

--- a/test/conn-channel-events.js
+++ b/test/conn-channel-events.js
@@ -1,0 +1,52 @@
+var log = require('debug')('servicebus:test');
+var sinon = require('sinon');
+var util = require('util');
+
+describe('servicebus', function(){
+
+  describe('#close', function() {
+
+    var bus;
+
+    beforeEach(function(done) {
+      bus = require('../').bus({ prefetch: 5, url: process.env.RABBITMQ_URL });
+
+      if (!bus.initialized) {
+        bus.on('ready', done);
+      } else {
+        done();
+      }
+    });
+
+    it('should emit connection_close event', function (done){
+
+      bus.on('connection_close', function (event) {
+        done();
+      });
+
+      bus.listen('my.event.50', function (event) {
+        bus.close();
+      });
+
+      setTimeout(function () {
+        bus.send('my.event.50', { my: 'event' });
+      }, 10);
+    });
+
+    it('should emit channel_close event', function (done){
+
+      bus.once('channel_close', function (event) {
+        done();
+      });
+
+      bus.listen('my.event.51', function (event) {
+        bus.close();
+      });
+
+      setTimeout(function () {
+        bus.send('my.event.51', { my: 'event' });
+      }, 10);
+    });
+
+  });
+});


### PR DESCRIPTION
This PR adds support for passing through the following additional events:
* `channel:close`
* `connection:close`
* `connection:error`

This allows users of `servicebus` to respond proactively to connectivity disruptions rather than wait until `send()` or `publish()` calls start failing.

There are additional events that may be worth passing through (`connection:block`, `connection:unblock`, `channel:return`, `channel:drain`), but I don't have a use case for them, so have not included them at this time.
