### PR TITLE
Convert content to string.

### DIFF
--- a/bus/formatters/json.js
+++ b/bus/formatters/json.js
@@ -1,7 +1,7 @@
 module.exports.deserialize = function deserialize (content) {
   
   try {
-    content = JSON.parse(content);
+    content = JSON.parse(content.toString());
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
In some cases I was getting Buffer from amqplib. And as a result an error was thrown each time. This workaround should help us to ensure we always have string in that place. Please add this fix to v1 of your lib as well.